### PR TITLE
Swapping the position of the labels [cluster, topic] to [topic, cluster]

### DIFF
--- a/cmd/internal/collector/collector.go
+++ b/cmd/internal/collector/collector.go
@@ -43,7 +43,7 @@ func (cc CCloudCollector) Collect(ch chan<- prometheus.Metric) {
 				desc,
 				prometheus.GaugeValue,
 				dataPoint.Value,
-				cc.cluster, dataPoint.Topic,
+				dataPoint.Topic, cc.cluster,
 			)
 			metricWithTime := prometheus.NewMetricWithTimestamp(dataPoint.Timestamp, metric)
 			ch <- metricWithTime


### PR DESCRIPTION
The labels values are incorrect. The cluster and topic values are swapped. 
Ex: ccloud_metric_received_bytes{cluster="lkc-0x9x2",topic="_confluent-monitoring"} 6072 1582626540000