### PR TITLE
Add endpoint and Json query when request failed (not status 200)

### DIFF
--- a/cmd/internal/collector/query.go
+++ b/cmd/internal/collector/query.go
@@ -125,7 +125,7 @@ func SendQuery(query Query) (QueryResponse, error) {
 	}
 
 	if res.StatusCode != 200 {
-		errorMsg := fmt.Sprintf("Received status code %d instead of 200", res.StatusCode)
+		errorMsg := fmt.Sprintf("Received status code %d instead of 200 for POST on %s with %s", res.StatusCode, endpoint, jsonQuery)
 		return QueryResponse{}, errors.New(errorMsg)
 	}
 


### PR DESCRIPTION
I receive a lot of error log of this kind but I don't know which request is involved
```log
Received status code 400 instead of 200
```
I would like have this one:
```log
Received status code 400 instead of 200 for POST on https://api.telemetry.confluent.cloud/v1/metrics/cloud/query with {"aggregations":[{"agg":"SUM","metric":"io.confluent.kafka.server/active_connection_count"}],"filter":{"op":"AND","filters":[{"field":"metric.label.cluster_id","op":"EQ","value":"lkc-aaaaa"}]},"granularity":"PT1M","group_by":["metric.label.topic"],"intervals":["2020-03-17T09:38:25+01:00/2020-03-17T09:39:25+01:00"],"limit":1000}
```
I think there is an issue with metrics active-connection-count request