### PR TITLE
Enable Topic Exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,14 @@ If you do not provide a configuration file, the exporter creates one from the pr
 
 #### Rule configuration
 
-| Key                | Description                                                                                                   |
-|--------------------|---------------------------------------------------------------------------------------------------------------|
-| rules.clusters     | List of clusters to fetch metrics from                                                                        |
-| rules.labels       | Labels to exposed to Prometheus and group by in the query                                                     |
-| rules.topics       | Optional list of topics to filter the metrics                                                                 |
-| rules.metrics      | List of metrics to gather                                                                                     |
+| Key                         | Description                                                                                                   |
+|-----------------------------|---------------------------------------------------------------------------------------------------------------|
+| rules.clusters              | List of clusters to fetch metrics from                                                                        |
+| rules.labels                | Labels to exposed to Prometheus and group by in the query                                                     |
+| rules.topics                | Optional list of topics to filter the metrics                                                                 |
+| rules.excludedTopics        | Optional list of topics to exclude from the query                                                             |
+| rules.excludedTopicsRegex   | Optional regex to filter the result of the query                                                              |
+| rules.metrics               | List of metrics to gather                                                                                     |
 
 ### Examples of configuration files
 

--- a/cmd/ccloudexporter/ccloudexporter.go
+++ b/cmd/ccloudexporter/ccloudexporter.go
@@ -11,8 +11,8 @@ import (
 	"github.com/Dabz/ccloudexporter/cmd/internal/collector"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
 	"net/http"
+	log "github.com/sirupsen/logrus"
 )
 
 func main() {

--- a/cmd/ccloudexporter/ccloudexporter.go
+++ b/cmd/ccloudexporter/ccloudexporter.go
@@ -11,8 +11,8 @@ import (
 	"github.com/Dabz/ccloudexporter/cmd/internal/collector"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"net/http"
 	log "github.com/sirupsen/logrus"
+	"net/http"
 )
 
 func main() {

--- a/cmd/internal/collector/collector.go
+++ b/cmd/internal/collector/collector.go
@@ -64,7 +64,7 @@ func (cc CCloudCollector) Collect(ch chan<- prometheus.Metric) {
 // CollectMetricsForRule collects all metrics for a specific rule
 func (cc CCloudCollector) CollectMetricsForRule(wg *sync.WaitGroup, ch chan<- prometheus.Metric, rule Rule, ccmetric CCloudCollectorMetric) {
 	defer wg.Done()
-	query := BuildQuery(ccmetric.metric, rule.Clusters, rule.GroupByLabels, rule.Topics, rule.excludeTopics)
+	query := BuildQuery(ccmetric.metric, rule.Clusters, rule.GroupByLabels, rule.Topics, rule.ExcludeTopics)
 	log.WithFields(log.Fields{"query": query}).Traceln("The following query has been created")
 	optimizedQuery, additionalLabels := OptimizeQuery(query)
 	log.WithFields(log.Fields{"optimizedQuery": optimizedQuery, "additionalLabels": additionalLabels}).Traceln("Query has been optimized")
@@ -101,7 +101,7 @@ func (cc CCloudCollector) handleResponse(response QueryResponse, ccmetric CCloud
 			continue METRICSLOOP
 		}
 
-		for _, currentRegex := range rule.excludeTopicsRegex {
+		for _, currentRegex := range rule.ExcludeTopicsRegex {
 			if matchesRegex(topic, currentRegex){
 				continue METRICSLOOP
 			}

--- a/cmd/internal/collector/collector_test.go
+++ b/cmd/internal/collector/collector_test.go
@@ -97,12 +97,12 @@ func TestHandleResponseForRegexFiltering(t *testing.T) {
 	}
 
 	var rule = Rule{
-		id:            0,
-		Topics:        []string{"topic"},
-		Clusters:      []string{"cluster"},
-		Metrics:       []string{"metric", "metric2"},
-		GroupByLabels: []string{"topic", "cluster_id"},
-		excludeTopicsRegex: []string{"excludedTopic*","excludedThing*"},
+		id:                 0,
+		Topics:             []string{"topic"},
+		Clusters:           []string{"cluster"},
+		Metrics:            []string{"metric", "metric2"},
+		GroupByLabels:      []string{"topic", "cluster_id"},
+		ExcludeTopicsRegex: []string{"excludedTopic*","excludedThing*"},
 	}
 
 	responseString := `

--- a/cmd/internal/collector/context.go
+++ b/cmd/internal/collector/context.go
@@ -24,8 +24,8 @@ type ExporterContext struct {
 // should collect for a specific set of topics or clusters
 type Rule struct {
 	Topics                           []string `mapstructure:"topics"`
-	excludeTopics					 []string `mapstructure:"excludeTopics"`
-	excludeTopicsRegex				 []string `mapstructure:"excludeTopicsRegex"`
+	ExcludeTopics                    []string `mapstructure:"ExcludeTopics"`
+	ExcludeTopicsRegex               []string `mapstructure:"ExcludeTopicsRegex"`
 	Clusters                         []string `mapstructure:"clusters"`
 	Metrics                          []string `mapstructure:"metrics"`
 	GroupByLabels                    []string `mapstructure:"labels"`

--- a/cmd/internal/collector/context.go
+++ b/cmd/internal/collector/context.go
@@ -24,6 +24,8 @@ type ExporterContext struct {
 // should collect for a specific set of topics or clusters
 type Rule struct {
 	Topics                           []string `mapstructure:"topics"`
+	excludeTopics					 []string `mapstructure:"excludeTopics"`
+	excludeTopicsRegex				 []string `mapstructure:"excludeTopicsRegex"`
 	Clusters                         []string `mapstructure:"clusters"`
 	Metrics                          []string `mapstructure:"metrics"`
 	GroupByLabels                    []string `mapstructure:"labels"`
@@ -41,7 +43,7 @@ type TopicClusterMetric struct {
 // Version is the git short SHA1 hash provided at build time
 var Version string = "homecooked"
 
-// Context is the global variable defining the context for the expoter
+// Context is the global variable defining the context for the exporter
 var Context = ExporterContext{}
 
 // DefaultGroupingLabels is the default value for groupBy.labels
@@ -65,7 +67,7 @@ var DefaultMetrics = []string{
 }
 
 // GetMapOfMetrics returns the whitelist of metrics in a map
-// where the key is the metric and the value is true if it is comming from an override
+// where the key is the metric and the value is true if it is coming from an override
 func (context ExporterContext) GetMapOfMetrics() map[string]bool {
 	mapOfWhiteListedMetrics := make(map[string]bool)
 

--- a/cmd/internal/collector/context_test.go
+++ b/cmd/internal/collector/context_test.go
@@ -1,5 +1,7 @@
 package collector
 
+import "testing"
+
 //
 // context_test.go
 // Copyright (C) 2020 gaspar_d </var/spool/mail/gaspar_d>
@@ -7,7 +9,6 @@ package collector
 // Distributed under terms of the MIT license.
 //
 
-import "testing"
 
 var rule1 = Rule{
 	id:            0,

--- a/cmd/internal/collector/context_test.go
+++ b/cmd/internal/collector/context_test.go
@@ -1,7 +1,5 @@
 package collector
 
-import "testing"
-
 //
 // context_test.go
 // Copyright (C) 2020 gaspar_d </var/spool/mail/gaspar_d>
@@ -9,6 +7,7 @@ import "testing"
 // Distributed under terms of the MIT license.
 //
 
+import "testing"
 
 var rule1 = Rule{
 	id:            0,

--- a/cmd/internal/collector/optimizer.go
+++ b/cmd/internal/collector/optimizer.go
@@ -16,12 +16,12 @@ package collector
 // labels (e.g. cluster_id will be removed if there is only cluster, thus
 // no need to group_by the result)
 func OptimizeQuery(input Query) (Query, map[string]string) {
-	optimizedQuery, optimizedLabel := removeSuperfluousGoupBy(input)
+	optimizedQuery, optimizedLabel := removeSuperfluousGroupBy(input)
 	return optimizedQuery, optimizedLabel
 }
 
 
-func removeSuperfluousGoupBy(input Query) (Query, map[string]string) {
+func removeSuperfluousGroupBy(input Query) (Query, map[string]string) {
 	optimizedGroupByList := make([]string, 0)
 	labels := make(map[string]string)
 	for _, groupBy := range input.GroupBy {

--- a/cmd/internal/collector/option.go
+++ b/cmd/internal/collector/option.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/spf13/viper"
 )
@@ -116,6 +117,10 @@ func validateConfiguration() {
 		if len(rule.GroupByLabels) == 0 {
 			fmt.Println("Labels is required while defining a rule")
 			os.Exit(1)
+		}
+
+		for _, currentRegex := range rule.excludeTopicsRegex {
+			regexp.MustCompile(currentRegex)
 		}
 	}
 }

--- a/cmd/internal/collector/option.go
+++ b/cmd/internal/collector/option.go
@@ -125,7 +125,7 @@ func validateConfiguration() {
 			log.Fatalln("Labels is required while defining a rule")
 		}
 
-		for _, currentRegex := range rule.excludeTopicsRegex {
+		for _, currentRegex := range rule.ExcludeTopicsRegex {
 			regexp.MustCompile(currentRegex)
 		}
 	}

--- a/cmd/internal/collector/query.go
+++ b/cmd/internal/collector/query.go
@@ -99,7 +99,7 @@ func BuildQuery(metric MetricDescription, clusters []string, groupByLabels []str
 	eligibleTopics := make([]string,0)
 	if len(topicFiltering) > 0 && len(excludeTopics) > 0{
 		for _, inTopic := range topicFiltering {
-			if !isWithin(inTopic,excludeTopics) {
+			if !contains(excludeTopics,inTopic) {
 				eligibleTopics = append(eligibleTopics,inTopic)
 			}
 		}
@@ -201,15 +201,4 @@ func SendQuery(query Query) (QueryResponse, error) {
 	json.Unmarshal(body, &response)
 
 	return response, nil
-}
-
-
-// Helper to determine whether an element is within a slice
-func isWithin(candidate string, listOfExclusions []string) bool {
-	for _, excluded := range listOfExclusions {
-		if candidate == excluded {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/internal/collector/query.go
+++ b/cmd/internal/collector/query.go
@@ -41,11 +41,11 @@ type FilterHeader struct {
 
 // Filter structure
 type Filter struct {
-	Field   string   `json:"field,omitempty"`
-	Op      string   `json:"op"`
-	Value   string   `json:"value,omitempty"`
-	Filters []Filter `json:"filters,omitempty"`
-	unaryFilter  *Filter   `json:"filter,omitempty"`
+	Field       string   `json:"field,omitempty"`
+	Op          string   `json:"op"`
+	Value       string   `json:"value,omitempty"`
+	Filters     []Filter `json:"filters,omitempty"`
+	UnaryFilter *Filter  `json:"filter,omitempty"`
 }
 
 // QueryResponse from the cloud endpoint
@@ -95,7 +95,7 @@ func BuildQuery(metric MetricDescription, clusters []string, groupByLabels []str
 		Filters: clusterFilters,
 	})
 
-	// Remove topics from the topicFiltering list if they also exist in the excludeTopics list
+	// Remove topics from the topicFiltering list if they also exist in the ExcludeTopics list
 	eligibleTopics := make([]string,0)
 	if len(topicFiltering) > 0 && len(excludeTopics) > 0{
 		for _, inTopic := range topicFiltering {
@@ -126,8 +126,8 @@ func BuildQuery(metric MetricDescription, clusters []string, groupByLabels []str
 				Value: exTopic,
 			}
 			wrapperNotFilter := Filter{
-				Op: "NOT",
-				unaryFilter: &excludeFilter,
+				Op:          "NOT",
+				UnaryFilter: &excludeFilter,
 			}
 			excludeTopicFilters = append(excludeTopicFilters, wrapperNotFilter)
 		}

--- a/cmd/internal/collector/query_test.go
+++ b/cmd/internal/collector/query_test.go
@@ -8,7 +8,6 @@ package collector
 //
 
 import (
-	"fmt"
 	"testing"
 )
 import "strings"
@@ -210,7 +209,6 @@ func TestBuildQueryWithIncludeAndExcludeTopic(t *testing.T) {
 	}
 
 	if query.Filter.Filters[1].Filters[0].Value != "topic" {
-		fmt.Println(query.Filter.Filters[1].Filters[0].Value)
 		t.Fail()
 	}
 
@@ -219,7 +217,6 @@ func TestBuildQueryWithIncludeAndExcludeTopic(t *testing.T) {
 	}
 
 	if query.Filter.Filters[1].Filters[1].unaryFilter.Value != "someOtherExcludedTopic" {
-		fmt.Println(query.Filter.Filters[1].Filters[0].Value)
 		t.Fail()
 	}
 }

--- a/cmd/internal/collector/query_test.go
+++ b/cmd/internal/collector/query_test.go
@@ -165,12 +165,12 @@ func TestBuildQueryWithExcludeTopic(t *testing.T) {
 		return
 	}
 
-	if query.Filter.Filters[1].Filters[0].unaryFilter.Field != "metric.label.topic" {
+	if query.Filter.Filters[1].Filters[0].UnaryFilter.Field != "metric.label.topic" {
 		t.Fail()
 		return
 	}
 
-	if query.Filter.Filters[1].Filters[0].unaryFilter.Value != "excludeTopicSample" {
+	if query.Filter.Filters[1].Filters[0].UnaryFilter.Value != "excludeTopicSample" {
 		t.Fail()
 		return
 	}

--- a/cmd/internal/collector/query_test.go
+++ b/cmd/internal/collector/query_test.go
@@ -7,9 +7,7 @@ package collector
 // Distributed under terms of the MIT license.
 //
 
-import (
-	"testing"
-)
+import "testing"
 import "strings"
 import "time"
 

--- a/cmd/internal/collector/query_test.go
+++ b/cmd/internal/collector/query_test.go
@@ -192,7 +192,7 @@ func TestBuildQueryWithIncludeAndExcludeTopic(t *testing.T) {
 
 	query := BuildQuery(metric, []string{"cluster"}, []string{"cluster_id", "topic", "partition"}, []string{"topic", "excludeTopicSample"}, []string{"excludeTopicSample", "someOtherExcludedTopic"})
 
-	if len(query.Filter.Filters) != 2 || len(query.Filter.Filters[1].Filters) != 2 {
+	if len(query.Filter.Filters) != 2 || len(query.Filter.Filters[1].Filters) != 1 {
 		t.Fail()
 	}
 
@@ -209,14 +209,6 @@ func TestBuildQueryWithIncludeAndExcludeTopic(t *testing.T) {
 	}
 
 	if query.Filter.Filters[1].Filters[0].Value != "topic" {
-		t.Fail()
-	}
-
-	if query.Filter.Filters[1].Filters[1].unaryFilter.Field != "metric.label.topic" {
-		t.Fail()
-	}
-
-	if query.Filter.Filters[1].Filters[1].unaryFilter.Value != "someOtherExcludedTopic" {
 		t.Fail()
 	}
 }

--- a/config/config.excludeTopics.yaml
+++ b/config/config.excludeTopics.yaml
@@ -1,0 +1,29 @@
+config:
+  http:
+    baseurl: https://api.telemetry.confluent.cloud/
+    timeout: 60
+  listener: 0.0.0.0:2112
+  noTimestamp: false
+  delay: 120
+  granularity: PT1M
+rules:
+  - clusters:
+      - lkc-8y75q
+    metrics:
+      - io.confluent.kafka.server/received_bytes
+      - io.confluent.kafka.server/sent_bytes
+      - io.confluent.kafka.server/received_records
+      - io.confluent.kafka.server/sent_records
+      - io.confluent.kafka.server/retained_bytes
+      - io.confluent.kafka.server/active_connection_count
+      - io.confluent.kafka.server/request_count
+      - io.confluent.kafka.server/partition_count
+      - io.confluent.kafka.server/successful_authentication_count
+    excludeTopics:
+      - MYSTREAM
+    excludeTopicsRegex:
+      - _*
+    labels:
+      - cluster_id
+      - topic
+      - type

--- a/config/config.excludeTopics.yaml
+++ b/config/config.excludeTopics.yaml
@@ -8,7 +8,7 @@ config:
   granularity: PT1M
 rules:
   - clusters:
-      - lkc-8y75q
+      - lkc-xxxxx
     metrics:
       - io.confluent.kafka.server/received_bytes
       - io.confluent.kafka.server/sent_bytes
@@ -20,9 +20,9 @@ rules:
       - io.confluent.kafka.server/partition_count
       - io.confluent.kafka.server/successful_authentication_count
     excludeTopics:
-      - MYSTREAM
+      - TEST
     excludeTopicsRegex:
-      - _*
+      - ^(_.+)$
     labels:
       - cluster_id
       - topic


### PR DESCRIPTION
Resolves #54.

## What changed?

The query will now be optimized to either:
- Include a filter in the query to not return a certain topic if said topic is included within rules.excludedTopics
- Remove a topic from the rules.topics list if it also exists in rules.excludedTopics

To filter results of a query, excludeTopicsRegex is now supported to not display results in the /metrics endpoint if it matches the regex provided. This regex field is a list, allowing the matching of multiple regex.

NOTE: Regex filtering does NOT improve the query, just removes the output.

## Is there any testing?

Yes, unit testing has been implemented in modified classes, namely:
- query_test.go
- collector_test.go

## Why is this a Draft PR?

The Confluent Metrics API currently is having some trouble with the Unary operator (used to optimize the query filtering).
This PR is not ready for merging until that filter quality is resolved and some more testing can happen.

## Open for discussion

First time contributing, so please critique my variable naming / style to conform to some other codebase implied standards.
I tried to adhere to them, hopefully there aren't that many hiccups. Some files are changed just because I found some typos.