### PR TITLE
Option to disable log pretty printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ccloud/
 ./ccloudexporter
+cmd/ccloudexporter/ccloudexporter

--- a/README.md
+++ b/README.md
@@ -28,23 +28,27 @@ To use the exporter, the following environment variables need to be specified:
 ```
 Usage of ./ccloudexporter:
   -cluster string
-    	Cluster ID to fetch metric for. If not specified, the environment variable CCLOUD_CLUSTER will be used
+        Cluster ID to fetch metric for. If not specified, the environment variable CCLOUD_CLUSTER will be used
   -config string
-    	Path to configuration file used to override default behavior of ccloudexporter
+        Path to configuration file used to override default behavior of ccloudexporter
   -delay int
-    	Delay, in seconds, to fetch the metrics. By default set to 120, this, in order to avoid temporary data points. (default 120)
+        Delay, in seconds, to fetch the metrics. By default set to 120, this, in order to avoid temporary data points. (default 120)
   -endpoint string
-    	Base URL for the Metric API (default "https://api.telemetry.confluent.cloud/")
+        Base URL for the Metric API (default "https://api.telemetry.confluent.cloud/")
   -granularity string
-    	Granularity for the metrics query, by default set to 1 minutes (default "PT1M")
+        Granularity for the metrics query, by default set to 1 minutes (default "PT1M")
   -listener string
-    	Listener for the HTTP interface (default ":2112")
+        Listener for the HTTP interface (default ":2112")
+  -log-pretty-print
+        Pretty print the JSON log output (default true)
   -no-timestamp
-    	Do not propagate the timestamp from the the metrics API to prometheus
+        Do not propagate the timestamp from the the metrics API to prometheus
   -timeout int
-    	Timeout, in second, to use for all REST call with the Metric API (default 60)
+        Timeout, in second, to use for all REST call with the Metric API (default 60)
+  -verbose
+        Print trace level logs to stdout
   -version
-    	Print the current version and exit
+        Print the current version and exit
 ```
 
 ## Examples

--- a/cmd/internal/collector/option.go
+++ b/cmd/internal/collector/option.go
@@ -33,10 +33,11 @@ func ParseOption() {
 	flag.BoolVar(&Context.NoTimestamp, "no-timestamp", false, "Do not propagate the timestamp from the the metrics API to prometheus")
 	versionFlag := flag.Bool("version", false, "Print the current version and exit")
 	verboseFlag := flag.Bool("verbose", false, "Print trace level logs to stdout")
+	prettyPrintLogs := flag.Bool("log-pretty-print", true, "Pretty print the JSON log output")
 
 	flag.Parse()
 
-	log.SetFormatter(&log.JSONFormatter{PrettyPrint: true})
+	log.SetFormatter(&log.JSONFormatter{PrettyPrint: *prettyPrintLogs})
 	log.SetOutput(os.Stdout)
 	if *verboseFlag {
 		log.SetLevel(log.TraceLevel)


### PR DESCRIPTION
Multi line JSON logs are not getting parsed by our logging system, adding an optional flag to disable this with `-log-pretty-print=false` so that the whole JSON object is printed on one line. Defaulting to the existing behaviour.

Example:

```bash
$ ./ccloudexporter
{
  "level": "fatal",
  "msg": "CCLOUD_API_KEY environment variable has not been specified",
  "time": "2021-01-05T10:20:58Z"
}
$ ./ccloudexporter -log-pretty-print=false
{"level":"fatal","msg":"CCLOUD_API_KEY environment variable has not been specified","time":"2021-01-05T10:14:52Z"}
```