### PR TITLE
Add a Grafana container (Docker Compose) with provisioned datasource and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Prometheus exporter for Confluent Cloud Metrics API
 
-A simple prometheus exporter that can be used to extract metrics from [Confluent Cloud Metric API](https://docs.confluent.io/current/cloud/metrics-api.html).
-By default, the exporter will be exposing the metrics on [port 2112](http://localhost:2112).
+A simple Prometheus exporter that can be used to extract metrics from [Confluent Cloud Metric API](https://docs.confluent.io/current/cloud/metrics-api.html).
+By default, the exporter will be exposing the metrics on [port 2112](http://localhost:2112).  When launching with Docker Compose, metrics are displayed via a Grafana dashboard on [http://localhost:3000](http://localhost:3000) (`admin`/`admin`).
+
 To use the exporter, the following environment variables need to be specified:
 
 * `CCLOUD_API_KEY`: The API Key created with `ccloud api-key create --resource cloud`
@@ -78,6 +79,8 @@ export CCLOUD_API_SECRET=XXXXXXXXXXXXXXXX
 export CCLOUD_CLUSTER=lkc-abc123
 docker-compose up -d
 ```
+In addition to the metrics exporter and Prometheus containers, the Docker Compose launch starts a [Grafana](https://github.com/grafana/grafana) on [http://localhost:3000](http://localhost:3000) (`admin`/`admin`).  The launch pre-provisions a Prometheus datasource for the Confluent Cloud metrics and a default dashboard.
+
 
 ### Using Kubernetes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
 
   prometheus:
     image: prom/prometheus
+    container_name: prometheus
     volumes:
       - ./prometheus.yml:/prometheus.yml
     command:
@@ -14,9 +15,21 @@ services:
 
   ccloud_exporter:
     image: dabz/ccloudexporter
+    container_name: ccloud_exporter
     environment:
       CCLOUD_API_KEY: ${CCLOUD_API_KEY}
       CCLOUD_API_SECRET: ${CCLOUD_API_SECRET}
       CCLOUD_CLUSTER: ${CCLOUD_CLUSTER}
       CCLOUD_CONNECTOR: ${CCLOUD_CONNECTOR}
       CCLOUD_KSQL: ${CCLOUD_KSQL}
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    depends_on:
+      - prometheus
+    command: cfg:default.log.level="debug"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    ports:
+      - 3000:3000

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,8 @@
+This directory contains provisioning artifacts and templates for adding a pre-built Grafana dashboards and datasource (Prometheus) to Grafana.
+These are automatically [provisioned](https://grafana.com/docs/grafana/latest/administration/provisioning/) in the Grafana instance started if using Docker Compose.
+
+- `ccloud-exporter.json`: JSON definition of Grafana dashboard, suitable for importing into the Grafana UI.
+- `provisioning/dashboards/ccloud-exporter.json`: Same dashboard template, but with the script `create-provisioning.sh` run over it, to replace the variable for the Prometheus datasource name with a real datasource name.  Grafana does not yet support [provisioning from templates that contain variables](https://github.com/grafana/grafana/issues/10786).
+- `provisioning/datasources/prometheus_ccloudexporter.yaml`: Provisions a standard Prometheus datasource for the provisioned dashboard to connect to.
+
+![Grafana](/grafana/grafana.png)

--- a/grafana/create-provisioning.sh
+++ b/grafana/create-provisioning.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+jq -n --arg DS_PROMETHEUS prometheus_ccloudexporter -f <(sed 's/"${DS_PROMETHEUS}"/$DS_PROMETHEUS/g' <ccloud-exporter.json) >provisioning/dashboards/ccloud-exporter.json

--- a/grafana/provisioning/dashboards/ccloud-exporter.json
+++ b/grafana/provisioning/dashboards/ccloud-exporter.json
@@ -57,7 +57,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -70,7 +70,7 @@
       "type": "row"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "The sum of partitions in a cluster. Basic cluster max partitions limit is 2048.",
       "fieldConfig": {
         "defaults": {
@@ -140,7 +140,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "Per-second average rate of ingress of data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
@@ -209,7 +209,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "Per-second average rate of egress data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
@@ -278,7 +278,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "Per-second average rate of requests, basic cluster maxes out at 1500 requests per second.",
       "fieldConfig": {
         "defaults": {
@@ -347,7 +347,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "Basic clusters have a max retained bytes limit of 5 TB prior to replication. ccloud_metrics_retained_bytes is after replication thus needs to be divided by 3.",
       "fieldConfig": {
         "defaults": {
@@ -416,7 +416,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "Basic clusters have a limit on the number of partitions that can be created and deleted in a 5 minute period. This single stat provides the absolute difference between the number of partitions are the beginning and end of the 5 minute period. This over simplifies the problem, so more conservative thresholds are put in place. ",
       "fieldConfig": {
         "defaults": {
@@ -487,7 +487,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -558,7 +558,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -628,7 +628,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -645,7 +645,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "The current count of bytes retained by the cluster, summed across all partitions. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -748,7 +748,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "The delta count of bytes received from the network. Each sample is the number of bytes received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -847,7 +847,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "The delta count of bytes sent over the network. Each sample is the number of bytes sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -947,7 +947,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "The delta count of records received. Each sample is the number of records received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1046,7 +1046,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "The delta count of records sent. Each sample is the number of records sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1145,7 +1145,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "description": "The delta count of requests received over the network. Each sample is the number of requests received since the previous data point. The count sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1245,7 +1245,7 @@
     },
     {
       "collapsed": true,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1255,7 +1255,7 @@
       "id": 33,
       "panels": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1314,7 +1314,7 @@
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1373,7 +1373,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1469,7 +1469,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1565,7 +1565,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1661,7 +1661,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "fieldConfig": {
             "defaults": {
               "custom": {}
@@ -1758,7 +1758,7 @@
     },
     {
       "collapsed": true,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1768,7 +1768,7 @@
       "id": 42,
       "panels": [
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1827,7 +1827,7 @@
           "type": "stat"
         },
         {
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -1891,7 +1891,7 @@
     },
     {
       "collapsed": true,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus_ccloudexporter",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1940,7 +1940,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "fieldConfig": {
             "defaults": {
               "custom": {},
@@ -2079,7 +2079,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
+          "datasource": "prometheus_ccloudexporter",
           "fieldConfig": {
             "defaults": {
               "custom": {},
@@ -2192,7 +2192,7 @@
       {
         "allValue": ".*",
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "prometheus_ccloudexporter",
         "definition": "label_values(ccloud_metric_retained_bytes, kafka_id)",
         "description": null,
         "error": null,
@@ -2216,7 +2216,7 @@
       {
         "allValue": "",
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "prometheus_ccloudexporter",
         "definition": "label_values(ccloud_metric_retained_bytes, topic)",
         "description": null,
         "error": null,

--- a/grafana/provisioning/dashboards/default.yaml
+++ b/grafana/provisioning/dashboards/default.yaml
@@ -1,0 +1,24 @@
+apiVersion: 1
+
+providers:
+  # <string> an unique provider name. Required
+  - name: 'a unique provider name'
+    # <int> Org id. Default to 1
+    orgId: 1
+    # <string> name of the dashboard folder.
+    folder: ''
+    # <string> folder UID. will be automatically generated if not specified
+    folderUid: ''
+    # <string> provider type. Default to 'file'
+    type: file
+    # <bool> disable dashboard deletion
+    disableDeletion: false
+    # <int> how often Grafana will scan for changed dashboards
+    updateIntervalSeconds: 10
+    # <bool> allow updating provisioned dashboards from the UI
+    allowUiUpdates: true
+    options:
+      # <string, required> path to dashboard files on disk. Required when using the 'file' type
+      path: /etc/grafana/provisioning/dashboards
+      # <bool> use folder names from filesystem to create folders in Grafana
+      foldersFromFilesStructure: true

--- a/grafana/provisioning/datasources/prometheus_ccloudexporter.yaml
+++ b/grafana/provisioning/datasources/prometheus_ccloudexporter.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+datasources:
+  - name: prometheus_ccloudexporter
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true


### PR DESCRIPTION
This PR adds a Grafana container (image `grafana/grafana`) to the Docker Compose based launch, to simplify running the complete stack pre-configured with `docker-compose up -d`.  This includes a pre-provisioned Grafana datasource referencing the Prometheus instance, which in-turn is scraping Confluent Cloud metrics, and a pre-provisioned dashboard.