### PR TITLE
DEVX-2519: Add links to ccloud-observability project

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Nonetheless, username/password is now **deprecated** and you **must** rely on AP
 
 # See Also
 
-For an example that showcases how to monitor Apache Kafka client applications, and steps through various failure scenarios to see how they are reflected in the provided metrics, see the [Observability for Apache Kafka® Clients to Confluent Cloud tutorial](https://docs.confluent.io/platform/current/tutorials/examples/ccloud-observability/docs/observability-overview.html).
+For a tutorial that showcases how to use ccloud-exporter, and steps through various failure scenarios to see how they are reflected in the provided metrics, see the [Observability for Apache Kafka® Clients to Confluent Cloud tutorial](https://docs.confluent.io/platform/current/tutorials/examples/ccloud-observability/docs/observability-overview.html).
 
 
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ Nonetheless, username/password is now **deprecated** and you **must** rely on AP
 
 # See Also
 
-For a tutorial that showcases how to use ccloud-exporter, and steps through various failure scenarios to see how they are reflected in the provided metrics, see the [Observability for Apache Kafka® Clients to Confluent Cloud tutorial](https://docs.confluent.io/platform/current/tutorials/examples/ccloud-observability/docs/observability-overview.html).
-
+For a tutorial that showcases how to use ccloudexporter, and steps through various failure scenarios to see how they are reflected in the provided metrics, see the [Observability for Apache Kafka® Clients to Confluent Cloud tutorial](https://docs.confluent.io/platform/current/tutorials/examples/ccloud-observability/docs/observability-overview.html).
 
 

--- a/README.md
+++ b/README.md
@@ -209,4 +209,9 @@ Nowadays, only the API key/secret is officially supported to connect to the Metr
 To ensure backward compatibility, previous environment variables are still available.
 Nonetheless, username/password is now **deprecated** and you **must** rely on API key/secret.
 
+# See Also
+
+For an example that showcases how to monitor Apache Kafka client applications, and steps through various failure scenarios to see how they are reflected in the provided metrics, see the [Observability for Apache Kafka® Clients to Confluent Cloud tutorial](https://docs.confluent.io/platform/current/tutorials/examples/ccloud-observability/docs/observability-overview.html).
+
+
 


### PR DESCRIPTION
@Dabz would you be open to adding a link like that proposed in this PR to the README? The goal of this is to drive traffic to this new tutorial where people will setup ccloud-exporter on a ccloud cluster and learn how to use the ccloud-exporter metrics. 