### PR TITLE
Added volumes for Prometheus and Grafana Compose services

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ docker-compose up -d
 ```
 In addition to the metrics exporter and Prometheus containers, the Docker Compose launch starts a [Grafana](https://github.com/grafana/grafana) on [http://localhost:3000](http://localhost:3000) (`admin`/`admin`).  The launch pre-provisions a Prometheus datasource for the Confluent Cloud metrics and a default dashboard.
 
+The Docker Compose service definitions include data volumes for both Prometheus and Grafana, so metrics data will be retained following `docker-compose down` and restored when containers are started again. To remove these volumes and start with empty Prometheus and Grafana databases, run `docker-compose down --volumes`.
 
 ### Using Kubernetes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     container_name: prometheus
     volumes:
       - ./prometheus.yml:/prometheus.yml
+      - prometheus-data:/prometheus
     command:
       - '--config.file=/prometheus.yml'
     ports:
@@ -31,5 +32,10 @@ services:
     command: cfg:default.log.level="debug"
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning
+      - grafana-data:/var/lib/grafana
     ports:
       - 3000:3000
+
+volumes:
+  prometheus-data:
+  grafana-data:


### PR DESCRIPTION
These volumes are per the recommended Docker Compose definitions for those containers.  I think it's somewhat better to have these and allow restarts without data-loss, at the cost of needing to know to clean-up those volumes if you want a clean system - this is easily done by adding `--volumes` to `docker-compose down`.

This has helped me with demonstrations of the Metrics API so I don't lose test data if containers are restarted, and with development.