### PR TITLE
Turn off log-pretty-print since log management systems are not able t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Usage of ./ccloudexporter:
   -listener string
     	Listener for the HTTP interface (default ":2112")
   -log-pretty-print
-    	Pretty print the JSON log output (default true)
+        Pretty print the JSON log output (default false)
   -no-timestamp
     	Do not propagate the timestamp from the the metrics API to prometheus
   -timeout int

--- a/cmd/internal/collector/option.go
+++ b/cmd/internal/collector/option.go
@@ -40,7 +40,7 @@ func ParseOption() {
 	flag.BoolVar(&Context.NoTimestamp, "no-timestamp", false, "Do not propagate the timestamp from the the metrics API to prometheus")
 	versionFlag := flag.Bool("version", false, "Print the current version and exit")
 	verboseFlag := flag.Bool("verbose", false, "Print trace level logs to stdout")
-	prettyPrintLogs := flag.Bool("log-pretty-print", true, "Pretty print the JSON log output")
+	prettyPrintLogs := flag.Bool("log-pretty-print", false, "Pretty print the JSON log output")
 
 	flag.Parse()
 


### PR DESCRIPTION
running this service kubernetes where we sends logs to log management system which is not able to parse that and create tons of events, it would be better to turn off by default.