### PR TITLE
Omit `agg` attribute from request

### DIFF
--- a/cmd/internal/collector/query.go
+++ b/cmd/internal/collector/query.go
@@ -33,7 +33,7 @@ type Query struct {
 
 // Aggregation for a Confluent Cloud API metric
 type Aggregation struct {
-	Agg    string `json:"agg"`
+	Agg    string `json:"agg,omitempty"`
 	Metric string `json:"metric"`
 }
 
@@ -78,7 +78,6 @@ func BuildQuery(metric MetricDescription, clusters []string, groupByLabels []str
 	timeFrom = timeFrom.Add(time.Duration(-timeFrom.Second()) * time.Second) // the seconds need to be stripped to have an effective delay
 
 	aggregation := Aggregation{
-		Agg:    "SUM",
 		Metric: metric.Name,
 	}
 
@@ -150,7 +149,6 @@ func BuildConnectorsQuery(metric MetricDescription, connectors []string, resourc
 	timeFrom = timeFrom.Add(time.Duration(-timeFrom.Second()) * time.Second) // the seconds need to be stripped to have an effective delay
 
 	aggregation := Aggregation{
-		Agg:    "SUM",
 		Metric: metric.Name,
 	}
 
@@ -197,7 +195,6 @@ func BuildKsqlQuery(metric MetricDescription, ksqlAppIds []string, resource Reso
 	timeFrom = timeFrom.Add(time.Duration(-timeFrom.Second()) * time.Second) // the seconds need to be stripped to have an effective delay
 
 	aggregation := Aggregation{
-		Agg:    "SUM",
 		Metric: metric.Name,
 	}
 
@@ -244,7 +241,6 @@ func BuildSchemaRegistryQuery(metric MetricDescription, schemaregistries []strin
 	timeFrom = timeFrom.Add(time.Duration(-timeFrom.Second()) * time.Second) // the seconds need to be stripped to have an effective delay
 
 	aggregation := Aggregation{
-		Agg:    "SUM",
 		Metric: metric.Name,
 	}
 


### PR DESCRIPTION
Omit the `agg` attribute from the Confluent Cloud Metrics API request instead of hardcoding `agg: "SUM"`.

The `agg` attribute has been optional in Metrics API for 8+ months.  If `agg` is not specified it defaults to the required aggregation for the metric.  Until recently, all of the metrics required the `SUM` aggregation.
However, new metrics are being added that use other aggregations (e.g. `MAX`). By hardcoding `agg: "SUM"`, we will get an error if we try to query such a metric.  By omitting the `agg` field, we are able to query the metric properly.