### PR TITLE
feat: Added `/health` endpoint

### DIFF
--- a/cmd/ccloudexporter/ccloudexporter.go
+++ b/cmd/ccloudexporter/ccloudexporter.go
@@ -22,6 +22,9 @@ func main() {
 	prometheus.MustRegister(ccollector)
 
 	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/health", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	})
 	log.Printf("Listening on http://%s/metrics\n", collector.Context.Listener)
 	err := http.ListenAndServe(collector.Context.Listener, nil)
 	if err != nil {


### PR DESCRIPTION
Hey @Dabz :wave: 

This should be a simple one - simply adding an extra `/health` endpoint so we're rate limited by Confluent cloud when we're simply doing liveness and readiness check on the exporter. Fixes https://github.com/Dabz/ccloudexporter/issues/86

Thanks!