### PR TITLE
Remove forward slash from query endpoint

### DIFF
--- a/cmd/internal/collector/query.go
+++ b/cmd/internal/collector/query.go
@@ -69,7 +69,7 @@ type QueryResponse struct {
 // }
 
 var (
-	queryURI = "/v2/metrics/cloud/query"
+	queryURI = "v2/metrics/cloud/query"
 )
 
 // BuildQuery creates a new Query for a metric for a specific cluster and time interval


### PR DESCRIPTION
If we look at here (for a different endpoint), We don't have the forward slash. https://github.com/Dabz/ccloudexporter/blob/master/cmd/internal/collector/descriptor.go#L66

Currently the API that is polled for query is `https://api.telemetry.confluent.cloud//v2/metrics/cloud/query`
If confluent cloud changes their url parser, we may have an issue. Thus, lets remove the slash.

On Readme, the default api that is suggested is with a trailing slash.
