### PR TITLE
Externalised API key variables for the metrics and lag exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,18 @@ Let's take a look at how to see the cloud metrics on Splunk dashboard. A docker-
 * This set up is done by tweaking the needed details [here](https://github.com/signalfx/splunk-otel-collector/tree/main/examples/prometheus-federation)
 
 ### How to run
-* Set CCloud-related parameters in both [docker.compose.yaml](./integration/splunk/docker-compose.yaml) and [application.conf](./integration/splunk/kafka-lag-exporter/application.conf) files
-* Run the [docker.compose.yaml](./integration/splunk/docker-compose.yaml) using command docker-compose up --build
-* Check analytics workspace [here](http://localhost:18000/en-US/app/search/analytics_workspace)
-* Metrics will show up like this:
+- Set CCloud-related parameters in both [docker.compose.yaml](./integration/splunk/docker-compose.yaml) and [application.conf](./integration/splunk/kafka-lag-exporter/application.conf) files.  Alternatively you can set these as environment variables before launching `docker-compose`:
+  - `CCLOUD_API_KEY`
+  - `CCLOUD_API_SECRET`
+  - `CCLOUD_CLUSTER`
+  - `CCLOUD_CONNECTOR`
+  - `CCLOUD_KSQL`
+  - `CCLOUD_ADMIN_API_KEY`
+  - `CCLOUD_ADMIN_API_SECRET`
+  - `CCLOUD_BOOTSTRAP_SERVER`
+- Run the [docker.compose.yaml](./integration/splunk/docker-compose.yaml) using command `docker-compose up --build`
+- Check analytics workspace [here](http://localhost:18000/en-US/app/search/analytics_workspace)
+- Metrics will show up like this:
   ![Splunk metrics screenshot](./integration/splunk/splunk.png)
 
 

--- a/integration/splunk/docker-compose.yaml
+++ b/integration/splunk/docker-compose.yaml
@@ -1,5 +1,7 @@
 version: "3"
+
 services:
+
   # Sample Go application producing counter metrics.
   ccloud_exporter:
     image: dabz/ccloudexporter
@@ -8,15 +10,22 @@ services:
     hostname: ccloud_exporter
     container_name: ccloud_exporter
     environment:
-      CCLOUD_API_KEY: <<CCLOUD_API_KEY>>
-      CCLOUD_API_SECRET: <<CCLOUD_API_SECRET>>
-      CCLOUD_CLUSTER: <<CCLOUD_CLUSTER>> #lkc-XXXX
+      CCLOUD_API_KEY: ${CCLOUD_API_KEY}
+      CCLOUD_API_SECRET: ${CCLOUD_API_SECRET}
+      CCLOUD_CLUSTER: ${CCLOUD_CLUSTER}
+      CCLOUD_CONNECTOR: ${CCLOUD_CONNECTOR}
+      CCLOUD_KSQL: ${CCLOUD_KSQL}
+
   # Import kafka-lag 
   kafka-lag-exporter:
-    image: lightbend/kafka-lag-exporter:0.5.5
+    image: lightbend/kafka-lag-exporter:0.6.7
     hostname: kafka-lag-exporter 
     container_name: kafka-lag-exporter 
     restart: always
+    environment:
+      CCLOUD_ADMIN_API_KEY: ${CCLOUD_ADMIN_API_KEY}
+      CCLOUD_ADMIN_API_SECRET: ${CCLOUD_ADMIN_API_SECRET}
+      CCLOUD_BOOTSTRAP_SERVER: ${CCLOUD_BOOTSTRAP_SERVER}
     ports:
      - 9999:9999
     volumes:
@@ -50,6 +59,7 @@ services:
       - ./splunk.yml:/tmp/defaults/default.yml
       - /opt/splunk/var
       - /opt/splunk/etc
+
   # OpenTelemetry Collector
   otelcollector:
     image: quay.io/signalfx/splunk-otel-collector:0.29.0

--- a/integration/splunk/kafka-lag-exporter/application.conf
+++ b/integration/splunk/kafka-lag-exporter/application.conf
@@ -5,13 +5,13 @@ kafka-lag-exporter {
 
   clusters = [
     {
-      name = "parking_lot_deals"
-      bootstrap-brokers = "<BOOTSTRAP_SERVER>" #Set bootstrap server from CCloud - starts with pkc-lalalalals:9092
+      name = "demo_cluster"
+      bootstrap-brokers = ${?CCLOUD_BOOTSTRAP_SERVER}
 
       admin-client-properties = {
         ssl.endpoint.identification.algorithm = "https"
         sasl.mechanism = "PLAIN"
-        sasl.jaas.config = "org.apache.kafka.common.security.plain.PlainLoginModule required username='<API_KEY>' password='<API_SECRET>';" #Set Cluster API key/secret
+        sasl.jaas.config = "org.apache.kafka.common.security.plain.PlainLoginModule required username='"${?CCLOUD_ADMIN_API_KEY}"' password='"${?CCLOUD_ADMIN_API_SECRET}"';"
         security.protocol = "SASL_SSL"
         request.timeout.ms = 200000
         retry.backoff.ms = 500
@@ -20,7 +20,7 @@ kafka-lag-exporter {
       consumer-properties = {
         ssl.endpoint.identification.algorithm = "https"
         sasl.mechanism = "PLAIN"
-        sasl.jaas.config = "org.apache.kafka.common.security.plain.PlainLoginModule required username='<API_KEY>' password='<API_SECRET>';" #Set Cluster API key/secret
+        sasl.jaas.config = "org.apache.kafka.common.security.plain.PlainLoginModule required username='"${?CCLOUD_ADMIN_API_KEY}"' password='"${?CCLOUD_ADMIN_API_SECRET}"';"
         security.protocol = "SASL_SSL"
         request.timeout.ms = 200000
         retry.backoff.ms = 500


### PR DESCRIPTION
This allows these to be set as environment variables and/or passed via Docker environment.

Updated kafka-lag-exporter Docker image to latest lightbend/kafka-lag-exporter:0.6.7 .