### PR TITLE
scrape the new metrics api v2 which supports openmetrics

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -6,5 +6,14 @@ scrape_configs:
     scrape_timeout: 30s
     honor_timestamps: true
     static_configs:
-      - targets: ['ccloud_exporter:2112']
+      - targets:
+        - api.telemetry.confluent.cloud
+    scheme: https
+    basic_auth:
+      username: <CCLOUD-API-KEY>
+      password: <CCLOUD-API-SECRET>
+    metrics_path: /v2/metrics/cloud/export
+    params:
+      "resource.kafka.id":
+        - lkc-xxx
 


### PR DESCRIPTION
scrape the new metrics api v2 which supports openmetrics, for details check documentation below

https://api.telemetry.confluent.cloud/docs#tag/Version-2/paths/~1v2~1metrics~1{dataset}~1query/post